### PR TITLE
check instream for atom map is not null before attempting to read from it

### DIFF
--- a/src/atom_typer.cpp
+++ b/src/atom_typer.cpp
@@ -423,6 +423,12 @@ void FileAtomMapper::setup(std::istream& in) {
 
 FileAtomMapper::FileAtomMapper(const std::string& fname, const std::vector<std::string>& type_names): old_type_names(type_names) {
   ifstream in(fname.c_str());
+
+  if(!in) {
+    std::cerr << "Could not open " << fname << "\n";
+    exit(-1);
+  }
+
   setup(in);
 }
 

--- a/src/atom_typer.cpp
+++ b/src/atom_typer.cpp
@@ -425,8 +425,7 @@ FileAtomMapper::FileAtomMapper(const std::string& fname, const std::vector<std::
   ifstream in(fname.c_str());
 
   if(!in) {
-    std::cerr << "Could not open " << fname << "\n";
-    exit(-1);
+    throw std::invalid_argument("Could not open " + fname);
   }
 
   setup(in);


### PR DESCRIPTION
check that you successfully opened the user-provided atom map file
before attempting to read from the resulting stream (which will exit
without an exception if the stream was null, producing an empty map that
fails later in a less informative way)