### PR TITLE
backward_grad() for higher order grid gradients

### DIFF
--- a/python/bindings.in.cpp
+++ b/python/bindings.in.cpp
@@ -775,20 +775,34 @@ MAKE_ALL_GRIDS()
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
           const Grid<float, 4, false>& diff, Grid<float, 2, false> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_2@")
+      .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
+          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,Grid<float, 4, false> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_1@")
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in, const Grid<float, 4, true>& diff,
           Grid<float, 2, true> atomic_gradients, Grid<float, 2, true> type_gradients){
           self.backward(grid_center, in, diff, atomic_gradients, type_gradients);}, "@Docstring_GridMaker_backward_3@")
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
           const Grid<float, 4, true>& diff, Grid<float, 2, true> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_4@")
+      .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
+          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,Grid<float, 4, true> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_2@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients) {
-              self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_5@")
+           self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_5@")
+       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
+           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
+           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients, Grid<float, 4, false> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_3@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
            const Grid<float, 4, true>& diff, Grid<float, 2, true> atom_gradients) {
-              self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_6@")
+           self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_6@")
+       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
+           const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
+           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients, Grid<float, 4, true> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_4@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 2, false>& type_vectors, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients, Grid<float, 2, false> type_gradients) {

--- a/src/grid_maker.cu
+++ b/src/grid_maker.cu
@@ -548,6 +548,55 @@ namespace libmolgrid {
       type_gradients(idx,whicht) = tgrad;
     }
 
+    template<typename Dtype>
+    __global__
+    void set_grid_gradients(GridMaker G, float3 grid_origin, Grid2fCUDA coords, Grid1fCUDA type_index,
+                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n, Grid<Dtype, 4, true> grid) {
+        int idx = blockDim.x * blockIdx.x + threadIdx.x;
+        if(idx >= type_index.dimension(0)) return;
+
+        //get atomic gradient for atom at idx
+        float3 agrad{0,0,0};
+        agrad.x = atom_gradients(idx,0);
+        agrad.y = atom_gradients(idx,1);
+        agrad.z = atom_gradients(idx,2);
+
+        //get true gradient for atom at idx
+        float3 tgrad{0,0,0};
+        tgrad.x = true_gradients(idx,0);
+        tgrad.y = true_gradients(idx,1);
+        tgrad.z = true_gradients(idx,2);
+
+        float3 a{coords(idx,0),coords(idx,1),coords(idx,2)}; //atom coordinate
+        float radius = radii(idx);
+
+        float r = radius * G.radius_scale * G.final_radius_multiple;
+        uint2 ranges[3];
+        ranges[0] = G.get_bounds_1d(grid_origin.x, a.x, r);
+        ranges[1] = G.get_bounds_1d(grid_origin.y, a.y, r);
+        ranges[2] = G.get_bounds_1d(grid_origin.z, a.z, r);
+
+        int whichgrid = round(type_index[idx]);
+        if(whichgrid < 0) return;
+        //Grid<Dtype, 3, true> diff = grid[whichgrid];
+
+        //for every grid point possibly overlapped by this atom
+        for (unsigned i = ranges[0].x, iend = ranges[0].y; i < iend; ++i) {
+            for (unsigned j = ranges[1].x, jend = ranges[1].y; j < jend; ++j) {
+                for (unsigned k = ranges[2].x, kend = ranges[2].y; k < kend; ++k) {
+                    //convert grid point coordinates to angstroms
+                    float x = grid_origin.x + i * G.resolution;
+                    float y = grid_origin.y + j * G.resolution;
+                    float z = grid_origin.z + k * G.resolution;
+                    size_t offset = ((((whichgrid * G.dim) + i) * G.dim) + j) * G.dim + k;
+
+                    G.accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n, (grid.data()+offset));
+                }
+            }
+        }
+
+    }
+
     //gpu accelerated gradient calculation
     template <typename Dtype>
     void GridMaker::backward(float3 grid_center, const Grid<float, 2, true>& coords,
@@ -656,6 +705,41 @@ namespace libmolgrid {
         agrad.z += -(dist_z / dist) * (agrad_dist * gridval);
       }
     }
+    template<typename Dtype>
+    void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
+            float x, float y, float z, float ar, float3& agrad, float3& tgrad,unsigned n,Dtype* gridval) const {
+        //calculate higher order gradient grid values overlapped by the atom for it's gradient loss.
+        float dist_x = x - ax;
+        float dist_y = y - ay;
+        float dist_z = z - az;
+        float dist2 = dist_x * dist_x + dist_y * dist_y + dist_z * dist_z;
+        float dist = sqrt(dist2);
+        float agrad_dist = 0.0;
+        ar *= radius_scale;
+        if (dist >= ar * final_radius_multiple) {//no overlap
+            return;
+        }
+        else if (dist <= ar * gaussian_radius_multiple) {//gaussian derivative
+            float ex = -2.0 * dist2 / (ar * ar);
+            float coef = -4.0 * dist / (ar * ar);
+            agrad_dist = coef * exp(ex);
+        }
+        else {//quadratic derivative
+            agrad_dist = (D*dist/ar + E)/ar;
+        }
+        // d_loss_gradient/d_grid_gradient = d_loss_gradient/d_atom_gradient * d_atom_gradient/d_grid_gradient
+        // d_atom_gradient/d_grid_gradient = d_atomdist/d_atomx * d_gridpoint/d_atomdist (from backward)
+        // implemented mean square error loss, negatives get cancelled out
+        if(dist > 0) {
+            *gridval += 2.0/n * (tgrad.x - agrad.x) *  (dist_x / dist) * (agrad_dist);
+            *gridval += 2.0/n * (tgrad.y - agrad.y) *  (dist_y / dist) * (agrad_dist);
+            *gridval += 2.0/n * (tgrad.z - agrad.z) *  (dist_z / dist) * (agrad_dist);
+        }
+    }
+    template void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
+                                                      float x, float y, float z, float ar,  float3& agrad, float3& tgrad, unsigned n,float* gridval) const;
+    template void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
+                             float x, float y, float z, float ar,  float3& agrad, float3& tgrad, unsigned n,double* gridval) const;
 
     //kernel launch - parallelize across whole atoms
     template<typename Dtype>
@@ -736,5 +820,36 @@ namespace libmolgrid {
     template void GridMaker::backward_relevance(float3,  const Grid<float, 2, true>&,
         const Grid<float, 1, true>&, const Grid<float, 1, true>&, const Grid<double, 4, true>&,
         const Grid<double, 4, true>&, Grid<double, 1, true>& ) const;
+
+    template <typename Dtype>
+    void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
+                             const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
+                             const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients, Grid<Dtype, 4, true>& grid) const {
+        grid.fill_zero();
+        unsigned n = coords.dimension(0);
+        if(n != type_index.size()) throw std::invalid_argument("Type dimension doesn't equal number of coordinates.");
+        if(n != radii.size()) throw std::invalid_argument("Radii dimension doesn't equal number of coordinates");
+        if(n != atom_gradients.dimension(0)) throw std::invalid_argument("Gradient dimension doesn't equal number of coordinates");
+        if(coords.dimension(1) != 3) throw std::invalid_argument("Coordinates wrong secondary dimension (!= 3)");
+        if(radii_type_indexed) {
+            throw std::invalid_argument("Type indexed radii not supported with index types.");
+        }
+
+        float3 grid_origin = get_grid_origin(grid_center);
+
+        unsigned blocks =  LMG_GET_BLOCKS(n);
+        unsigned nthreads = LMG_GET_THREADS(n);
+        set_grid_gradients<<<blocks, nthreads>>>(*this, grid_origin, coords, type_index, radii, atom_gradients, true_gradients,n,grid);
+    }
+
+    template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
+                                      const Grid<float, 1, true>& type_index,const Grid<float, 1, true>& radii,
+                                      const Grid<float, 2, true>& atom_gradients,const Grid<float, 2, true>& true_gradients, Grid<float, 4, true>& grid) const;
+    template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
+                                      const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
+                                      const Grid<double, 2, true>& atom_gradients,const Grid<double, 2, true>& true_gradients,Grid<double, 4, true>& grid) const;
+
+
+
 
 } /* namespace libmolgrid */

--- a/test/test_gridmaker.cpp
+++ b/test/test_gridmaker.cpp
@@ -174,7 +174,6 @@ BOOST_AUTO_TEST_CASE(backward) {
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(backward_relevance) {
   using namespace std;
   GridMaker g(0.1, 6.0);
@@ -201,6 +200,74 @@ BOOST_AUTO_TEST_CASE(backward_relevance) {
   BOOST_CHECK_GT(cpurel(0), 1.0);
   BOOST_CHECK_LT(cpurel(0), 10.0);
 
+}
+
+BOOST_AUTO_TEST_CASE(backward_grad) {
+    using namespace std;
+    GridMaker g(0.1, 6.0);
+
+    vector<float3> c{make_float3(0, 0, 0)};
+    vector<int> t{0};
+    vector<float> r{2.0};
+
+    CoordinateSet coords(c, t, r, 1);
+    float dim = g.get_grid_dims().x;
+
+    MGrid4f diff_cpu(1, dim, dim, dim);
+    MGrid4f diff_gpu(1, dim, dim, dim);
+
+    MGrid2f atomgrad(1, 3);
+    MGrid2f truegrad(1, 3);
+
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), truegrad.cpu(), diff_cpu.cpu());
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), truegrad.gpu(), diff_gpu.gpu());
+
+    for (unsigned i = 0; i < 30; i++){
+        for (unsigned j = 0; j < 30; j++){
+            for (unsigned k = 0; k < 30; k++){
+                //all values should be zero
+                BOOST_CHECK_SMALL(diff_cpu(0, i,j,k), TOL);
+                BOOST_CHECK_SMALL(diff_cpu(0, 60-i,60-j,60-k), TOL);
+                BOOST_CHECK_SMALL(diff_gpu(0, i,j,k), TOL);
+                BOOST_CHECK_SMALL(diff_gpu(0, 60-i,60-j,60-k), TOL);
+            }
+        }
+    }
+
+    //check origin
+    BOOST_CHECK_SMALL(diff_cpu(0, 30,30,30), TOL);
+    BOOST_CHECK_SMALL(diff_gpu(0, 30,30,30), TOL);
+
+    //Provide loss
+    truegrad(0,0)=1.0;
+    truegrad(0,1)=1.0;
+    truegrad(0,2)=1.0;
+
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), truegrad.cpu(), diff_cpu.cpu());
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), truegrad.gpu(), diff_gpu.gpu());
+
+    //Check for not all zeros
+    BOOST_CHECK_GT(diff_cpu(0, 29,29,29), TOL);
+    BOOST_CHECK_LT(diff_cpu(0, 31,31,31), -TOL);
+
+    for (unsigned i = 11; i < 30; i++){
+        for (unsigned j = 11; j < 30; j++){
+            for (unsigned k = 11; k < 30; k++){
+                // >= 0
+                BOOST_CHECK_GT(diff_cpu(0, i,j,k), -TOL);
+                // <=0
+                BOOST_CHECK_LT(diff_cpu(0, 60-i,60-j,60-k), TOL);
+                // GPU-CPU=0
+                BOOST_CHECK_SMALL(diff_gpu(0, i,j,k)-diff_cpu(0, i,j,k), TOL);
+                BOOST_CHECK_SMALL(diff_gpu(0, 60-i,60-j,60-k)-diff_cpu(0, 60-i,60-j,60-k), TOL);
+                //Symmetry check
+                BOOST_CHECK_SMALL(diff_cpu(0, i,j,k)+diff_cpu(0, 60-i,60-j,60-k), TOL);
+            }
+        }
+    }
+    //check origin
+    BOOST_CHECK_SMALL(diff_cpu(0, 30,30,30), TOL);
+    BOOST_CHECK_SMALL(diff_gpu(0, 30,30,30), TOL);
 }
 
 BOOST_AUTO_TEST_CASE(backward_vec) {


### PR DESCRIPTION
backward_grad() provides higher order grid gradients that are propagated back from MSE loss on atomic gradients. 