### PR TITLE
1-cossim() loss on atom gradients

### DIFF
--- a/include/libmolgrid/grid_maker.h
+++ b/include/libmolgrid/grid_maker.h
@@ -470,13 +470,14 @@ class GridMaker {
      * @param[in] coordinate set
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out] a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, false>& atomic_gradients,const Grid<Dtype, 2, false>& true_gradients,Grid<Dtype, 4, false>& diff) const {
+                  const Grid<Dtype, 2, false>& atomic_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, true_gradients,diff);
+            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, true_gradients,cossim,diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set"); //could setup dummy types here
         }
@@ -490,13 +491,14 @@ class GridMaker {
      * @param[in] coordinate set
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out] diff a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, true>& atomic_gradients, const Grid<Dtype, 2, true>& true_gradients,Grid<Dtype, 4, true>& diff ) const {
+                  const Grid<Dtype, 2, true>& atomic_gradients, const Grid<Dtype, 2, true>& true_gradients,bool cossim,Grid<Dtype, 4, true>& diff ) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, true_gradients, diff);
+            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, true_gradients,cossim, diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set");
         }
@@ -511,12 +513,13 @@ class GridMaker {
      * @param[in] radii (N)
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,Grid<Dtype, 4, false>& diff) const;
+                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const;
 
     // Docstring_GridMaker_backward_4
     /* \brief Generate higher order grid gradients from atomic gradient loss. (GPU)
@@ -527,12 +530,13 @@ class GridMaker {
      * @param[in] radii (N)
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                   const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-                  const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients, Grid<Dtype, 4, true>& grid ) const;
+                  const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients,bool cossim, Grid<Dtype, 4, true>& grid ) const;
 
     /* \brief The function that actually updates the voxel density values.
      * @param[in] natoms number of possibly relevant atoms
@@ -577,7 +581,7 @@ class GridMaker {
 
     //calculate higher order grid gradient for single atom - cpu
     template <typename Dtype>
-    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, const Grid<Dtype, 1, false>& true_gradient,const unsigned n, Dtype* gridptr)const;
+    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, const Grid<Dtype, 1, false>& true_gradient,const unsigned n,bool cossim, Dtype* gridptr)const;
 
     /* \brief Find grid indices in one dimension that bound an atom's density.
      * @param[in] grid_origin grid min coordinate in a given dimension
@@ -608,7 +612,7 @@ class GridMaker {
     //accumulate higher order gradient from provided atom at ax,ay,az for grid point x,y,z
     template <typename Dtype>
     CUDA_CALLABLE_MEMBER void accumulate_grid_gradient(float ax, float ay, float az,
-                                                       float x, float y, float z, float radius, float3& agrad, float3& tgrad,unsigned n,Dtype* gridval) const;
+                                                       float x, float y, float z, float radius, float3& agrad, float3& tgrad,unsigned n,bool cossim,Dtype* gridval) const;
 
     template<typename Dtype> __global__ friend //member functions don't kernel launch
     void set_atom_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
@@ -622,7 +626,7 @@ class GridMaker {
         Grid1fCUDA radii, Grid<Dtype, 4, true> densitygrid, Grid<Dtype, 4, true> diffgrid, Grid<Dtype, 1, true> relevance);
     template<typename Dtype> __global__ friend
     void set_grid_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
-                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,Grid<Dtype, 4, true> grid);
+                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,bool cossim,Grid<Dtype, 4, true> grid);
 };
 
 } /* namespace libmolgrid */

--- a/python/bindings.in.cpp
+++ b/python/bindings.in.cpp
@@ -776,8 +776,8 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, false>& diff, Grid<float, 2, false> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_2@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,Grid<float, 4, false> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_1@")
+          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,bool cossim,Grid<float, 4, false> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_1@")
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in, const Grid<float, 4, true>& diff,
           Grid<float, 2, true> atomic_gradients, Grid<float, 2, true> type_gradients){
           self.backward(grid_center, in, diff, atomic_gradients, type_gradients);}, "@Docstring_GridMaker_backward_3@")
@@ -785,24 +785,24 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, true>& diff, Grid<float, 2, true> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_4@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,Grid<float, 4, true> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_2@")
+          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,bool cossim,Grid<float, 4, true> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_2@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_5@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients, Grid<float, 4, false> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_3@")
+           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_3@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
            const Grid<float, 4, true>& diff, Grid<float, 2, true> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_6@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients, Grid<float, 4, true> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_4@")
+           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients,bool cossim Grid<float, 4, true> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_4@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 2, false>& type_vectors, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients, Grid<float, 2, false> type_gradients) {

--- a/src/grid_maker.cpp
+++ b/src/grid_maker.cpp
@@ -397,7 +397,7 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
 
 // set corresponding higher order grid gradient values for a single atom
     template <typename Dtype>
-    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient,const Grid<Dtype, 1, false>& true_gradient, const unsigned n, Dtype* gridptr) const {
+    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient,const Grid<Dtype, 1, false>& true_gradient, const unsigned n,bool cossim, Dtype* gridptr) const {
 
         //get atomic gradient for atom at idx
         float3 agrad{0,0,0};
@@ -430,7 +430,7 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
                     float y = grid_origin.y + j * resolution;
                     float z = grid_origin.z + k * resolution;
                     size_t offset = (((i) * dim) + j) * dim + k;
-                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n, (gridptr+offset)) ;
+                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n,cossim, (gridptr+offset)) ;
                 }
             }
         }
@@ -561,7 +561,7 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
     template <typename Dtype>
     void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients, Grid<Dtype, 4, false>& diff) const {
+                                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim, Grid<Dtype, 4, false>& diff) const {
 
         diff.fill_zero();
         unsigned n = coords.dimension(0);
@@ -586,15 +586,15 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
                 }
                 //offset = ((((whichgrid * G.dim) + i) * G.dim) + j) * G.dim + k; (thus power of 3)
                 size_t offset = (whichgrid * pow(dim,3.0));
-                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i],true_gradients[i], n, (diff.data()+offset));
+                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i],true_gradients[i], n,cossim, (diff.data()+offset));
             }
         }
     }
 
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                           const Grid<float, 2, false>& atom_gradients,const Grid<float, 2, false>& true_gradients, Grid<float, 4, false>& diff) const;
+                                           const Grid<float, 2, false>& atom_gradients,const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false>& diff) const;
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
-                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,const Grid<double, 2, false>& true_gradients,Grid<double, 4, false>& diff) const;
+                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,const Grid<double, 2, false>& true_gradients,bool cossim,Grid<double, 4, false>& diff) const;
 
 }


### PR DESCRIPTION
Provide the option to backprop 1-cossim() loss from atom gradients to the grid. Partial derivatives of cossim() here: https://math.stackexchange.com/questions/1923613/partial-derivative-of-cosine-similarity 

Gradients may vanish/blow up for large/small magnitudes of the vectors.