### PR TITLE
backward_grad() to help with backprop from atomic gradient loss

### DIFF
--- a/include/libmolgrid/grid_maker.h
+++ b/include/libmolgrid/grid_maker.h
@@ -470,13 +470,14 @@ class GridMaker {
      * @param[in] coordinate set
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out] a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, false>& atomic_gradients,const Grid<Dtype, 2, false>& true_gradients,Grid<Dtype, 4, false>& diff) const {
+                  const Grid<Dtype, 2, false>& atomic_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, true_gradients,diff);
+            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, true_gradients,cossim,diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set"); //could setup dummy types here
         }
@@ -490,13 +491,14 @@ class GridMaker {
      * @param[in] coordinate set
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out] diff a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, true>& atomic_gradients, const Grid<Dtype, 2, true>& true_gradients,Grid<Dtype, 4, true>& diff ) const {
+                  const Grid<Dtype, 2, true>& atomic_gradients, const Grid<Dtype, 2, true>& true_gradients,bool cossim,Grid<Dtype, 4, true>& diff ) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, true_gradients, diff);
+            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, true_gradients,cossim, diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set");
         }
@@ -511,12 +513,13 @@ class GridMaker {
      * @param[in] radii (N)
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,Grid<Dtype, 4, false>& diff) const;
+                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const;
 
     // Docstring_GridMaker_backward_4
     /* \brief Generate higher order grid gradients from atomic gradient loss. (GPU)
@@ -527,12 +530,13 @@ class GridMaker {
      * @param[in] radii (N)
      * @param[in] atomic_gradients vector quantities for each atom
      * @param[in] true_gradients vector quantities for each atom
+     * @param[in] Bool to backprop cossim loss
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                   const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-                  const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients, Grid<Dtype, 4, true>& grid ) const;
+                  const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients,bool cossim, Grid<Dtype, 4, true>& grid ) const;
 
     /* \brief The function that actually updates the voxel density values.
      * @param[in] natoms number of possibly relevant atoms
@@ -577,7 +581,7 @@ class GridMaker {
 
     //calculate higher order grid gradient for single atom - cpu
     template <typename Dtype>
-    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, const Grid<Dtype, 1, false>& true_gradient,const unsigned n, Dtype* gridptr)const;
+    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, const Grid<Dtype, 1, false>& true_gradient,const unsigned n,bool cossim, Dtype* gridptr)const;
 
     /* \brief Find grid indices in one dimension that bound an atom's density.
      * @param[in] grid_origin grid min coordinate in a given dimension
@@ -608,7 +612,7 @@ class GridMaker {
     //accumulate higher order gradient from provided atom at ax,ay,az for grid point x,y,z
     template <typename Dtype>
     CUDA_CALLABLE_MEMBER void accumulate_grid_gradient(float ax, float ay, float az,
-                                                       float x, float y, float z, float radius, float3& agrad, float3& tgrad,unsigned n,Dtype* gridval) const;
+                                                       float x, float y, float z, float radius, float3& agrad, float3& tgrad,unsigned n,bool cossim,Dtype* gridval) const;
 
     template<typename Dtype> __global__ friend //member functions don't kernel launch
     void set_atom_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
@@ -622,7 +626,7 @@ class GridMaker {
         Grid1fCUDA radii, Grid<Dtype, 4, true> densitygrid, Grid<Dtype, 4, true> diffgrid, Grid<Dtype, 1, true> relevance);
     template<typename Dtype> __global__ friend
     void set_grid_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
-                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,Grid<Dtype, 4, true> grid);
+                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,bool cossim,Grid<Dtype, 4, true> grid);
 };
 
 } /* namespace libmolgrid */

--- a/include/libmolgrid/grid_maker.h
+++ b/include/libmolgrid/grid_maker.h
@@ -463,80 +463,72 @@ class GridMaker {
 
 
     // Docstring_GridMaker_backward_grad_1
-    /* \brief Generate higher order grid gradients from atomic gradient loss. (CPU)
+    /* \brief Continue backprop from higher order atomic gradient loss. (CPU)
      * Must provide atom coordinates that defined the original grid in forward
      * Index types are required
      * @param[in] center of grid
      * @param[in] coordinate set
-     * @param[in] atomic_gradients vector quantities for each atom
-     * @param[in] true_gradients vector quantities for each atom
-     * @param[in] Bool to backprop cossim loss
+     * @param[in] atomic higher order gradient vector quantities for each atom
      * @param[out] a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, false>& atomic_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const {
+                  const Grid<Dtype, 2, false>& atomic_gradients,Grid<Dtype, 4, false>& diff) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, true_gradients,cossim,diff);
+            backward_grad(grid_center, in.coords.cpu(), in.type_index.cpu(), in.radii.cpu(),  atomic_gradients, diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set"); //could setup dummy types here
         }
     }
 
     // Docstring_GridMaker_backward_grad_2
-    /* \brief Generate higher order grid gradients from atomic gradient loss. (GPU)
+    /* \brief Continue backprop from higher order atomic gradient loss. (GPU)
      * Must provide atom coordinates that defined the original grid in forward
      * Index types are required.
      * @param[in] center of grid
      * @param[in] coordinate set
-     * @param[in] atomic_gradients vector quantities for each atom
-     * @param[in] true_gradients vector quantities for each atom
-     * @param[in] Bool to backprop cossim loss
+     * @param[in] atomic higher order gradient vector quantities for each atom
      * @param[out] diff a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const CoordinateSet& in,
-                  const Grid<Dtype, 2, true>& atomic_gradients, const Grid<Dtype, 2, true>& true_gradients,bool cossim,Grid<Dtype, 4, true>& diff ) const {
+                  const Grid<Dtype, 2, true>& atomic_gradients,Grid<Dtype, 4, true>& diff ) const {
         if(in.has_indexed_types()) {
-            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, true_gradients,cossim, diff);
+            backward_grad(grid_center, in.coords.gpu(), in.type_index.gpu(), in.radii.gpu(), atomic_gradients, diff);
         } else {
             throw std::invalid_argument("Index types missing from coordinate set");
         }
     }
 
     // Docstring_GridMaker_backward_3
-    /* \brief Generate higher order grid gradients from atomic gradient loss. (CPU)
+    /* \brief Continue backprop from higher order atomic gradient loss. (CPU)
      * Must provide atom coordinates, types, and radii that defined the original grid in forward
      * @param[in] center of grid
      * @param[in] coordinates (Nx3)
      * @param[in] type indices (N integers stored as floats)
      * @param[in] radii (N)
-     * @param[in] atomic_gradients vector quantities for each atom
-     * @param[in] true_gradients vector quantities for each atom
-     * @param[in] Bool to backprop cossim loss
+     * @param[in] atomic higher order gradient vector quantities for each atom
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim,Grid<Dtype, 4, false>& diff) const;
+                  const Grid<Dtype, 2, false>& atom_gradients,Grid<Dtype, 4, false>& diff) const;
 
     // Docstring_GridMaker_backward_4
-    /* \brief Generate higher order grid gradients from atomic gradient loss. (GPU)
+    /* \brief Continue backprop from higher order atomic gradient loss. (GPU)
      * Must provide atom coordinates, types, and radii that defined the original grid in forward
      * @param[in] center of grid
      * @param[in] coordinates(Nx3)
      * @param[in] type indices (N integers stored as floats)
      * @param[in] radii (N)
-     * @param[in] atomic_gradients vector quantities for each atom
-     * @param[in] true_gradients vector quantities for each atom
-     * @param[in] Bool to backprop cossim loss
+     * @param[in] atomic higher order gradient vector quantities for each atom
      * @param[out]a 4D grid of higher order gradients
      */
     template <typename Dtype>
     void backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                   const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-                  const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients,bool cossim, Grid<Dtype, 4, true>& grid ) const;
+                  const Grid<Dtype, 2, true>& atom_gradients, Grid<Dtype, 4, true>& grid ) const;
 
     /* \brief The function that actually updates the voxel density values.
      * @param[in] natoms number of possibly relevant atoms
@@ -581,7 +573,7 @@ class GridMaker {
 
     //calculate higher order grid gradient for single atom - cpu
     template <typename Dtype>
-    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, const Grid<Dtype, 1, false>& true_gradient,const unsigned n,bool cossim, Dtype* gridptr)const;
+    void calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coord, float radius, const Grid<Dtype, 1, false>& atom_gradient, Dtype* gridptr)const;
 
     /* \brief Find grid indices in one dimension that bound an atom's density.
      * @param[in] grid_origin grid min coordinate in a given dimension
@@ -612,7 +604,7 @@ class GridMaker {
     //accumulate higher order gradient from provided atom at ax,ay,az for grid point x,y,z
     template <typename Dtype>
     CUDA_CALLABLE_MEMBER void accumulate_grid_gradient(float ax, float ay, float az,
-                                                       float x, float y, float z, float radius, float3& agrad, float3& tgrad,unsigned n,bool cossim,Dtype* gridval) const;
+                                                       float x, float y, float z, float radius, float3& agrad, Dtype* gridval) const;
 
     template<typename Dtype> __global__ friend //member functions don't kernel launch
     void set_atom_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
@@ -626,7 +618,7 @@ class GridMaker {
         Grid1fCUDA radii, Grid<Dtype, 4, true> densitygrid, Grid<Dtype, 4, true> diffgrid, Grid<Dtype, 1, true> relevance);
     template<typename Dtype> __global__ friend
     void set_grid_gradients(GridMaker G, float3 grid_center, Grid2fCUDA coords, Grid1fCUDA type_index,
-                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,bool cossim,Grid<Dtype, 4, true> grid);
+                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 4, true> grid);
 };
 
 } /* namespace libmolgrid */

--- a/python/bindings.in.cpp
+++ b/python/bindings.in.cpp
@@ -776,8 +776,8 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, false>& diff, Grid<float, 2, false> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_2@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,bool cossim,Grid<float, 4, false> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_1@")
+          const Grid<float, 2, false>& atomic_gradients, Grid<float, 4, false> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, diff); }, "@Docstring_GridMaker_backward_grad_1@")
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in, const Grid<float, 4, true>& diff,
           Grid<float, 2, true> atomic_gradients, Grid<float, 2, true> type_gradients){
           self.backward(grid_center, in, diff, atomic_gradients, type_gradients);}, "@Docstring_GridMaker_backward_3@")
@@ -785,24 +785,24 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, true>& diff, Grid<float, 2, true> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_4@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,bool cossim,Grid<float, 4, true> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_2@")
+          const Grid<float, 2, true>& atomic_gradients,Grid<float, 4, true> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, diff); }, "@Docstring_GridMaker_backward_grad_2@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_5@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_3@")
+           const Grid<float, 2, false>& atom_gradients, Grid<float, 4, false> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,diff);}, "@Docstring_GridMaker_backward_grad_3@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
            const Grid<float, 4, true>& diff, Grid<float, 2, true> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_6@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients,bool cossim Grid<float, 4, true> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_4@")
+           const Grid<float, 2, true>& atom_gradients, Grid<float, 4, true> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,diff);}, "@Docstring_GridMaker_backward_grad_4@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 2, false>& type_vectors, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients, Grid<float, 2, false> type_gradients) {

--- a/python/bindings.in.cpp
+++ b/python/bindings.in.cpp
@@ -776,8 +776,8 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, false>& diff, Grid<float, 2, false> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_2@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,Grid<float, 4, false> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_1@")
+          const Grid<float, 2, false>& atomic_gradients, const Grid<float, 2, false>& true_gradients,bool cossim,Grid<float, 4, false> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_1@")
       .def("backward", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in, const Grid<float, 4, true>& diff,
           Grid<float, 2, true> atomic_gradients, Grid<float, 2, true> type_gradients){
           self.backward(grid_center, in, diff, atomic_gradients, type_gradients);}, "@Docstring_GridMaker_backward_3@")
@@ -785,24 +785,24 @@ MAKE_ALL_GRIDS()
           const Grid<float, 4, true>& diff, Grid<float, 2, true> atomic_gradients) {
           self.backward(grid_center, in, diff, atomic_gradients); }, "@Docstring_GridMaker_backward_4@")
       .def("backward_grad", +[](GridMaker& self, float3 grid_center, const CoordinateSet& in,
-          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,Grid<float, 4, true> diff) {
-          self.backward_grad(grid_center, in, atomic_gradients, true_gradients, diff); }, "@Docstring_GridMaker_backward_grad_2@")
+          const Grid<float, 2, true>& atomic_gradients, const Grid<float, 2, true>& true_gradients,bool cossim,Grid<float, 4, true> diff) {
+          self.backward_grad(grid_center, in, atomic_gradients, true_gradients,cossim, diff); }, "@Docstring_GridMaker_backward_grad_2@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_5@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients, Grid<float, 4, false> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_3@")
+           const Grid<float, 2, false>& atom_gradients, const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_3@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
            const Grid<float, 4, true>& diff, Grid<float, 2, true> atom_gradients) {
            self.backward(grid_center, coords, type_index, radii, diff, atom_gradients);}, "@Docstring_GridMaker_backward_6@")
        .def("backward_grad", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, true>& coords,
            const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients, Grid<float, 4, true> diff) {
-           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,diff);}, "@Docstring_GridMaker_backward_grad_4@")
+           const Grid<float, 2, true>& atom_gradients, const Grid<float, 2, true>& true_gradients,bool cossim Grid<float, 4, true> diff) {
+           self.backward_grad(grid_center, coords, type_index, radii, atom_gradients,true_gradients,cossim,diff);}, "@Docstring_GridMaker_backward_grad_4@")
        .def("backward", +[](GridMaker& self, float3 grid_center, const Grid<float, 2, false>& coords,
            const Grid<float, 2, false>& type_vectors, const Grid<float, 1, false>& radii,
            const Grid<float, 4, false>& diff, Grid<float, 2, false> atom_gradients, Grid<float, 2, false> type_gradients) {

--- a/src/grid_maker.cpp
+++ b/src/grid_maker.cpp
@@ -397,19 +397,13 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
 
 // set corresponding higher order grid gradient values for a single atom
     template <typename Dtype>
-    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient,const Grid<Dtype, 1, false>& true_gradient, const unsigned n,bool cossim, Dtype* gridptr) const {
+    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient, Dtype* gridptr) const {
 
         //get atomic gradient for atom at idx
         float3 agrad{0,0,0};
         agrad.x = atom_gradient(0);
         agrad.y = atom_gradient(1);
         agrad.z = atom_gradient(2);
-
-        //get true gradient for atom at idx
-        float3 tgrad{0,0,0};
-        tgrad.x = true_gradient(0);
-        tgrad.y = true_gradient(1);
-        tgrad.z = true_gradient(2);
 
         float r = radius * radius_scale * final_radius_multiple;
         float3 a{coordr(0),coordr(1),coordr(2)}; //atom coordinate
@@ -430,7 +424,7 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
                     float y = grid_origin.y + j * resolution;
                     float z = grid_origin.z + k * resolution;
                     size_t offset = (((i) * dim) + j) * dim + k;
-                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n,cossim, (gridptr+offset)) ;
+                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, (gridptr+offset)) ;
                 }
             }
         }
@@ -561,7 +555,7 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
     template <typename Dtype>
     void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim, Grid<Dtype, 4, false>& diff) const {
+                                  const Grid<Dtype, 2, false>& atom_gradients, Grid<Dtype, 4, false>& diff) const {
 
         diff.fill_zero();
         unsigned n = coords.dimension(0);
@@ -586,15 +580,15 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
                 }
                 //offset = ((((whichgrid * G.dim) + i) * G.dim) + j) * G.dim + k; (thus power of 3)
                 size_t offset = (whichgrid * pow(dim,3.0));
-                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i],true_gradients[i], n,cossim, (diff.data()+offset));
+                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i], (diff.data()+offset));
             }
         }
     }
 
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                           const Grid<float, 2, false>& atom_gradients,const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false>& diff) const;
+                                           const Grid<float, 2, false>& atom_gradients, Grid<float, 4, false>& diff) const;
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
-                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,const Grid<double, 2, false>& true_gradients,bool cossim,Grid<double, 4, false>& diff) const;
+                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,Grid<double, 4, false>& diff) const;
 
 }

--- a/src/grid_maker.cpp
+++ b/src/grid_maker.cpp
@@ -397,7 +397,7 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
 
 // set corresponding higher order grid gradient values for a single atom
     template <typename Dtype>
-    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient,const Grid<Dtype, 1, false>& true_gradient, const unsigned n, Dtype* gridptr) const {
+    void GridMaker::calc_grid_gradient_cpu(const float3& grid_origin, const Grid1f& coordr, float radius,const Grid<Dtype, 1, false>& atom_gradient,const Grid<Dtype, 1, false>& true_gradient, const unsigned n,bool cossim, Dtype* gridptr) const {
 
         //get atomic gradient for atom at idx
         float3 agrad{0,0,0};
@@ -430,7 +430,7 @@ float GridMaker::calc_atom_relevance_cpu(const float3& grid_origin, const Grid1f
                     float y = grid_origin.y + j * resolution;
                     float z = grid_origin.z + k * resolution;
                     size_t offset = (((i) * dim) + j) * dim + k;
-                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n, (gridptr+offset)) ;
+                    accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n,cossim, (gridptr+offset)) ;
                 }
             }
         }
@@ -561,7 +561,7 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
     template <typename Dtype>
     void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                   const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients, Grid<Dtype, 4, false>& diff) const {
+                                  const Grid<Dtype, 2, false>& atom_gradients,const Grid<Dtype, 2, false>& true_gradients,bool cossim, Grid<Dtype, 4, false>& diff) const {
 
         diff.fill_zero();
         unsigned n = coords.dimension(0);
@@ -586,15 +586,15 @@ template void GridMaker::backward_relevance(float3,  const Grid<float, 2, false>
                 }
                 //offset = ((((whichgrid * G.dim) + i) * G.dim) + j) * G.dim + k; (thus power of 3)
                 size_t offset = (whichgrid * pow(dim,3.0));
-                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i],true_gradients[i], n, (diff.data()+offset));
+                calc_grid_gradient_cpu(grid_origin, coords[i], radii[i], atom_gradients[i],true_gradients[i], n,cossim, (diff.data()+offset));
             }
         }
     }
 
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
                                            const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,
-                                           const Grid<float, 2, false>& atom_gradients,const Grid<float, 2, false>& true_gradients, Grid<float, 4, false>& diff) const;
+                                           const Grid<float, 2, false>& atom_gradients,const Grid<float, 2, false>& true_gradients,bool cossim, Grid<float, 4, false>& diff) const;
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, false>& coords,
-                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,const Grid<double, 2, false>& true_gradients,Grid<double, 4, false>& diff) const;
+                                           const Grid<float, 1, false>& type_index, const Grid<float, 1, false>& radii,const Grid<double, 2, false>& atom_gradients,const Grid<double, 2, false>& true_gradients,bool cossim,Grid<double, 4, false>& diff) const;
 
 }

--- a/src/grid_maker.cu
+++ b/src/grid_maker.cu
@@ -551,7 +551,7 @@ namespace libmolgrid {
     template<typename Dtype>
     __global__
     void set_grid_gradients(GridMaker G, float3 grid_origin, Grid2fCUDA coords, Grid1fCUDA type_index,
-                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients, Grid<Dtype, 2, true> true_gradients, unsigned n,bool cossim, Grid<Dtype, 4, true> grid) {
+                            Grid1fCUDA radii, Grid<Dtype, 2, true> atom_gradients,  Grid<Dtype, 4, true> grid) {
         int idx = blockDim.x * blockIdx.x + threadIdx.x;
         if(idx >= type_index.dimension(0)) return;
 
@@ -561,11 +561,6 @@ namespace libmolgrid {
         agrad.y = atom_gradients(idx,1);
         agrad.z = atom_gradients(idx,2);
 
-        //get true gradient for atom at idx
-        float3 tgrad{0,0,0};
-        tgrad.x = true_gradients(idx,0);
-        tgrad.y = true_gradients(idx,1);
-        tgrad.z = true_gradients(idx,2);
 
         float3 a{coords(idx,0),coords(idx,1),coords(idx,2)}; //atom coordinate
         float radius = radii(idx);
@@ -590,7 +585,7 @@ namespace libmolgrid {
                     float z = grid_origin.z + k * G.resolution;
                     size_t offset = ((((whichgrid * G.dim) + i) * G.dim) + j) * G.dim + k;
 
-                    G.accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, tgrad, n,cossim, (grid.data()+offset));
+                    G.accumulate_grid_gradient(a.x, a.y, a.z, x, y, z, radius, agrad, (grid.data()+offset));
                 }
             }
         }
@@ -707,7 +702,7 @@ namespace libmolgrid {
     }
     template<typename Dtype>
     void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
-            float x, float y, float z, float ar, float3& agrad, float3& tgrad,unsigned n,bool cossim,Dtype* gridval) const {
+            float x, float y, float z, float ar, float3& agrad,Dtype* gridval) const {
         //calculate higher order gradient grid values overlapped by the atom for it's gradient loss.
         float dist_x = x - ax;
         float dist_y = y - ay;
@@ -725,41 +720,19 @@ namespace libmolgrid {
             agrad_dist = coef * exp(ex);
         }
         else {//quadratic derivative
-            agrad_dist = (D*dist/ar + E)/ar;
+            agrad_dist = (D * dist / ar + E) / ar;
         }
-        // d_loss_gradient/d_grid_gradient = d_loss_gradient/d_atom_gradient * d_atom_gradient/d_grid_gradient
-        // d_atom_gradient/d_grid_gradient = d_atomdist/d_atomx * d_gridpoint/d_atomdist (from backward)
         if(dist > 0) {
-            if (cossim) {
-                float agrad_vec2 = agrad.x * agrad.x + agrad.y * agrad.y + agrad.z * agrad.z;
-                float tgrad_vec2 = tgrad.x * tgrad.x + tgrad.y * tgrad.y + tgrad.z * tgrad.z;
-                if (agrad_vec2 > 0 && tgrad_vec2 > 0) {
-                    float agrad_vec = sqrt(agrad_vec2);
-                    float tgrad_vec = sqrt(tgrad_vec2);
-                    float cosine = (agrad.x * tgrad.x + agrad.y * tgrad.y + agrad.z * tgrad.z) /
-                                   (agrad_vec * tgrad_vec);
-                    //1-cossim() loss
-
-                    *gridval += 1.0f / n * ((tgrad.x / (agrad_vec * tgrad_vec)) -
-                            (cosine * agrad.x / (agrad_vec2 ))) * (dist_x / dist) * (agrad_dist);
-                    *gridval += 1.0f / n * ((tgrad.y / (agrad_vec * tgrad_vec)) -
-                            (cosine * agrad.y / (agrad_vec2 ))) * (dist_y / dist) * (agrad_dist);
-                    *gridval += 1.0f / n * ((tgrad.z / (agrad_vec * tgrad_vec)) -
-                            (cosine * agrad.z / (agrad_vec2 ))) * (dist_z / dist) * (agrad_dist);
-                }
-            }
-            else {
-                // implemented mean square error loss, negatives get cancelled out
-                *gridval += 2.0f / n * (tgrad.x - agrad.x) * (dist_x / dist) * (agrad_dist);
-                *gridval += 2.0f / n * (tgrad.y - agrad.y) * (dist_y / dist) * (agrad_dist);
-                *gridval += 2.0f / n * (tgrad.z - agrad.z) * (dist_z / dist) * (agrad_dist);
-            }
+                // d_atom_gradient/d_grid_gradient = d_atomdist/d_atomx * d_gridpoint/d_atomdist (from backward)
+                *gridval += agrad.x * -(dist_x / dist) * (agrad_dist);
+                *gridval += agrad.y * -(dist_y / dist) * (agrad_dist);
+                *gridval += agrad.z * -(dist_z / dist) * (agrad_dist);
         }
     }
     template void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
-                                                      float x, float y, float z, float ar,  float3& agrad, float3& tgrad, unsigned n,bool cossim,float* gridval) const;
+                                                      float x, float y, float z, float ar,  float3& agrad, float* gridval) const;
     template void GridMaker::accumulate_grid_gradient(float ax, float ay, float az,
-                                                      float x, float y, float z, float ar,  float3& agrad, float3& tgrad, unsigned n,bool cossim,double* gridval) const;
+                                                      float x, float y, float z, float ar,  float3& agrad, double* gridval) const;
 
     //kernel launch - parallelize across whole atoms
     template<typename Dtype>
@@ -844,7 +817,7 @@ namespace libmolgrid {
     template <typename Dtype>
     void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                              const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-                             const Grid<Dtype, 2, true>& atom_gradients,const Grid<Dtype, 2, true>& true_gradients,bool cossim, Grid<Dtype, 4, true>& grid) const {
+                             const Grid<Dtype, 2, true>& atom_gradients, Grid<Dtype, 4, true>& grid) const {
         grid.fill_zero();
         unsigned n = coords.dimension(0);
         if(n != type_index.size()) throw std::invalid_argument("Type dimension doesn't equal number of coordinates.");
@@ -859,15 +832,15 @@ namespace libmolgrid {
 
         unsigned blocks =  LMG_GET_BLOCKS(n);
         unsigned nthreads = LMG_GET_THREADS(n);
-        set_grid_gradients<<<blocks, nthreads>>>(*this, grid_origin, coords, type_index, radii, atom_gradients, true_gradients,n,cossim,grid);
+        set_grid_gradients<<<blocks, nthreads>>>(*this, grid_origin, coords, type_index, radii, atom_gradients,grid);
     }
 
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                                       const Grid<float, 1, true>& type_index,const Grid<float, 1, true>& radii,
-                                      const Grid<float, 2, true>& atom_gradients,const Grid<float, 2, true>& true_gradients,bool cossim, Grid<float, 4, true>& grid) const;
+                                      const Grid<float, 2, true>& atom_gradients, Grid<float, 4, true>& grid) const;
     template void GridMaker::backward_grad(float3 grid_center, const Grid<float, 2, true>& coords,
                                       const Grid<float, 1, true>& type_index, const Grid<float, 1, true>& radii,
-                                      const Grid<double, 2, true>& atom_gradients,const Grid<double, 2, true>& true_gradients,bool cossim,Grid<double, 4, true>& grid) const;
+                                      const Grid<double, 2, true>& atom_gradients,Grid<double, 4, true>& grid) const;
 
 
 

--- a/test/test_gridmaker.cpp
+++ b/test/test_gridmaker.cpp
@@ -219,16 +219,13 @@ BOOST_AUTO_TEST_CASE(backward_grad) {
     MGrid2f atomgrad(1, 3);
     MGrid2f truegrad(1, 3);
 
-    atomgrad(0,0)=-10.0f;
-    atomgrad(0,1)=-1.0f;
-    atomgrad(0,2)=-7.0f;
+    atomgrad(0,0)=0.0f;
+    atomgrad(0,1)=0.0f;
+    atomgrad(0,2)=0.0f;
     //zero loss
-    truegrad(0,0)=-10.0f;
-    truegrad(0,1)=-1.0f;
-    truegrad(0,2)=-7.0f;
-    //No loss for cossimilarity
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), truegrad.cpu(),true, diff_cpu.cpu());
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), truegrad.gpu(),true, diff_gpu.gpu());
+
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), diff_cpu.cpu());
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), diff_gpu.gpu());
 
     for (unsigned i = 0; i < 30; i++){
         for (unsigned j = 0; j < 30; j++){
@@ -242,50 +239,18 @@ BOOST_AUTO_TEST_CASE(backward_grad) {
         }
     }
 
-    //check origin
-    BOOST_CHECK_SMALL(diff_cpu(0, 30,30,30), TOL);
-    BOOST_CHECK_SMALL(diff_gpu(0, 30,30,30), TOL);
 
     //Provide loss
-    truegrad(0,0)=4.0f;
-    truegrad(0,1)=3.5f;
-    truegrad(0,2)=2.0f;
-    //cossim loss
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), truegrad.cpu(),true, diff_cpu.cpu());
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), truegrad.gpu(),true, diff_gpu.gpu());
+    atomgrad(0,0)=-2.0f;
+    truegrad(0,1)=-2.0f;
+    truegrad(0,2)=-2.0f;
+
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), diff_cpu.cpu());
+    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), diff_gpu.gpu());
 
     //Check for not all zeros
     BOOST_CHECK_GT(diff_cpu(0, 29,29,29), TOL);
     BOOST_CHECK_LT(diff_cpu(0, 31,31,31), -TOL);
-    float cossim_val1=diff_gpu(0, 29,29,29);
-    float cossim_val2=diff_cpu(0, 31,31,31);
-
-    for (unsigned i =0; i < 30; i++){
-        for (unsigned j = 0; j < 30; j++){
-            for (unsigned k = 0; k < 30; k++){
-                // GPU-CPU=0
-                BOOST_CHECK_SMALL(diff_gpu(0, i,j,k)-diff_cpu(0, i,j,k), TOL);
-                BOOST_CHECK_SMALL(diff_gpu(0, 60-i,60-j,60-k)-diff_cpu(0, 60-i,60-j,60-k), TOL);
-                //Symmetry check
-                BOOST_CHECK_SMALL(diff_cpu(0, i,j,k)+diff_cpu(0, 60-i,60-j,60-k), TOL);
-            }
-        }
-    }
-    //check origin
-    BOOST_CHECK_SMALL(diff_cpu(0, 30,30,30), TOL);
-    BOOST_CHECK_SMALL(diff_gpu(0, 30,30,30), TOL);
-
-    //MSE loss
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.cpu(), truegrad.cpu(),false, diff_cpu.cpu());
-    g.backward_grad(float3 { 0, 0, 0 }, coords, atomgrad.gpu(), truegrad.gpu(),false, diff_gpu.gpu());
-
-    //Check for not all zeros
-    BOOST_CHECK_GT(diff_cpu(0, 29,29,29), TOL);
-    BOOST_CHECK_LT(diff_cpu(0, 31,31,31), -TOL);
-
-    //Check if different from cossim loss
-    BOOST_CHECK_GT(abs(cossim_val1 - diff_cpu(0, 29,29,29)), TOL);
-    BOOST_CHECK_GT(abs(cossim_val2 - diff_cpu(0, 31,31,31)), TOL);
 
     for (unsigned i =0; i < 30; i++){
         for (unsigned j = 0; j < 30; j++){


### PR DESCRIPTION
backward_grad() is used to continue the autoprop chain for the operations that are not tracked by pytorch. 

Usage example:
```
# get grid gradients
gradspred, = torch.autograd.grad(output, input_tensor,
                                   grad_outputs=output.data.new(output.shape).fill_(1),
                                   create_graph=True)

# get atomic gradients
gmaker.backward(example.coord_sets[1].center(), example.coord_sets[1], gradspred[0],atomic_grads)

# loss and start backprop
loss= 1 - torch.cosine_similarity(atomic_grads,desired_grads,dim=1)
loss.mean().backward()

# atomic gradients from loss backprop
higher_grad=atomic_grads.grad

# continue backprop chain
grad_tensor = torch.zeros(tensor_shape, dtype=torch.float32,device='cuda')
gmaker.backward_grad(example.coord_sets[1].center(), example.coord_sets[1],higher_grad,grad_tensor[0])
gradspred.backward(gradient=grad_tensor)
```