### PR TITLE
MolDataset fixes

### DIFF
--- a/python/torch_bindings.py
+++ b/python/torch_bindings.py
@@ -188,16 +188,20 @@ class MolDataset(torch.utils.data.Dataset):
         ex = self.examples[idx]
         center = torch.tensor([i for i in ex.coord_sets[-1].center()])
         coordinates = ex.merge_coordinates()
-        coords = torch.tensor(coordinates.coords.tonumpy()) 
-        atomtypes = torch.nn.functional.one_hot(torch.tensor(coordinates.type_index.tonumpy(),dtype=torch.long), num_classes=coordinates.num_types()).type('torch.FloatTensor')
-        radii = torch.tensor(coordinates.radii.tonumpy()) 
+        if coordinates.has_vector_types() and coordinates.size() > 0:
+            atomtypes = torch.tensor(coordinates.type_vector.tonumpy(),dtype=torch.long).type('torch.FloatTensor')
+        else:
+            atomtypes = torch.tensor(coordinates.type_index.tonumpy(),dtype=torch.long).type('torch.FloatTensor')
+        coords = torch.tensor(coordinates.coords.tonumpy())
+        radii = torch.tensor(coordinates.radii.tonumpy())
         labels = [ex.labels[lab] for lab in range(self.num_labels)]
-        return center,coords,atomtypes,radii, labels
+        return center, coords, atomtypes, radii, labels
     
     def __getstate__(self):
         settings = self.examples.settings()
-        keyword_dict = {sett: getattr(settings,sett) for sett in dir(settings) if not sett.startswith('__')}
-        if self.typers is not None:
+        keyword_dict = {sett: getattr(settings, sett) for sett in dir(settings) if not sett.startswith('__')}
+        if self.typers is not None: ## This will fail if self.typers is not none, need a way to pickle AtomTypers
+            raise NotImplementedError('MolDataset does not support pickling when not using the default Gnina atom typers, this uses %s'.format(str(self.typers)))
             keyword_dict['typers'] = self.typers
         return keyword_dict, self.types_files
 
@@ -207,7 +211,7 @@ class MolDataset(torch.utils.data.Dataset):
         if 'typers' in kwargs:
             typers = kwargs['typers']
             del kwargs['typers']
-            self.examples = mg.ExampleDataset(*typers,**kwargs)
+            self.examples = mg.ExampleDataset(*typers, **kwargs)
             self.typers = typers
         else:
             self.examples = mg.ExampleDataset(**kwargs)

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -323,26 +323,28 @@ def test_example_provider_iterator_interface():
 def test_pytorch_dataset():
     fname = datadir+"/small.types"
     
-    e = molgrid.MolDataset(fname,data_root=datadir+"/structs")
-    ert = molgrid.MolDataset(fname,data_root=datadir+"/structs",random_rotation=True,random_translation=2.0)
+    e = molgrid.ExampleProvider(data_root=datadir+"/structs")
+    e.populate(fname)
+    m = molgrid.MolDataset(fname,data_root=datadir+"/structs")
     
-    assert len(e) == 1000
-    assert len(ert) == 1000
+    assert len(m) == 1000
 
-    grid, labels = e[1]
-    gridrt, labelsrt = ert[1]
+    ex = e.next()
+    coordinates = ex.merge_coordinates()
 
-    assert grid.shape[0] == molgrid.defaultGninaReceptorTyper.num_types() + molgrid.defaultGninaLigandTyper.num_types()
-    assert sum(grid.shape[1:]) == 48*3
-    assert (grid.sum(axis=[1,2,3]).nonzero() == gridrt.sum(axis=[1,2,3]).nonzero()).all()
+    center, coords, types, radii, labels = e[0]
+
+    assert center.shape == (1,3)
+    assert (coords == coordinates.coords.tonumpy()).all().item()
+    assert (types == coordinates.types_index.tonumpy()).all().item()
+    assert (radii == coordinates.radii.tonumpy()).all().item()
 
     assert len(labels) == 3
     assert labels[0] == 1
     np.testing.assert_allclose(labels[1],6.05)
     np.testing.assert_allclose(labels[-1],0.162643)
-    assert labels == labelsrt
 
-    grids, labels =e[-1]
+    center, coords, types, radii, labels =e[-1]
     assert labels[0] == 0
     np.testing.assert_allclose(labels[1], -10.3)    
         


### PR DESCRIPTION
Output of MolDataset when accessing an item is now: center, coordinates, types, radii, and labels
This allows the user to call `gmaker.forward` on the GPU.

Additionally MolDataset is now picklable.
However, there is an error if someone tries to pickle a MolDataset that does not use the default Gnina typing.
I'm not sure this error can be fixed unless the pickling of all of the Atom Typers is enabled.