### PR TITLE
MolDataset Test Fixes and Collate Function

### DIFF
--- a/python/torch_bindings.py
+++ b/python/torch_bindings.py
@@ -220,3 +220,32 @@ class MolDataset(torch.utils.data.Dataset):
         self.examples.populate(self.types_files)
 
         self.num_labels = self.examples.num_labels()
+
+    @staticmethod
+    def collateMolDataset(batch):
+        '''collate_fn for use in torch.utils.data.Dataloader when using the MolDataset.
+        Returns lengths, centers, coords, types, radii, labels all padded to fit maximum size of batch'''
+        lens = []
+        centers = []
+        lcoords = []
+        ltypes = []
+        lradii = []
+        labels = []
+        for center,coords,types,radii,label in batch:
+            lens.append(coords.shape[0])
+            centers.append(center)
+            lcoords.append(coords)
+            ltypes.append(types)
+            lradii.append(radii.unsqueeze(1))
+            labels.append(torch.tensor(label))
+
+
+        lengths = torch.tensor(lens)
+        lcoords = torch.nn.utils.rnn.pad_sequence(lcoords, batch_first=True)
+        ltypes = torch.nn.utils.rnn.pad_sequence(ltypes, batch_first=True)
+        lradii = torch.nn.utils.rnn.pad_sequence(lradii, batch_first=True)
+
+        centers = torch.stack(centers,dim=0)
+        labels = torch.stack(labels,dim=0)
+
+        return lengths, centers, lcoords, ltypes, lradii, labels

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -332,19 +332,19 @@ def test_pytorch_dataset():
     ex = e.next()
     coordinates = ex.merge_coordinates()
 
-    center, coords, types, radii, labels = e[0]
+    center, coords, types, radii, labels = m[0]
 
-    assert center.shape == (1,3)
-    assert (coords == coordinates.coords.tonumpy()).all().item()
-    assert (types == coordinates.types_index.tonumpy()).all().item()
-    assert (radii == coordinates.radii.tonumpy()).all().item()
+    assert list(center.shape) == [3]
+    np.testing.assert_allclose(coords, coordinates.coords.tonumpy())
+    np.testing.assert_allclose(types, coordinates.type_index.tonumpy())
+    np.testing.assert_allclose(radii, coordinates.radii.tonumpy())
 
     assert len(labels) == 3
     assert labels[0] == 1
     np.testing.assert_allclose(labels[1],6.05)
     np.testing.assert_allclose(labels[-1],0.162643)
 
-    center, coords, types, radii, labels =e[-1]
+    center, coords, types, radii, labels = m[-1]
     assert labels[0] == 0
     np.testing.assert_allclose(labels[1], -10.3)    
         

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -347,6 +347,29 @@ def test_pytorch_dataset():
     center, coords, types, radii, labels = m[-1]
     assert labels[0] == 0
     np.testing.assert_allclose(labels[1], -10.3)    
+
+    '''Testing out the collate_fn when used with torch.utils.data.DataLoader'''
+    torch_loader = torch.utils.data.DataLoader(      
+        m, batch_size=8,collate_fn=molgrid.MolDataset.collateMolDataset)
+    iterator = iter(torch_loader)
+    next(iterator)
+    lengths, center, coords, types, radii, labels = next(iterator)
+    assert len(lengths) == 8
+    assert center.shape[0] == 8
+    assert coords.shape[0] == 8
+    assert types.shape[0] == 8
+    assert radii.shape[0] == 8
+    assert radii.shape[0] == 8
+    assert labels.shape[0] == 8
+
+    mcenter, mcoords, mtypes, mradii, mlabels = m[10]
+    np.testing.assert_allclose(center[2],mcenter) 
+    np.testing.assert_allclose(coords[2][:lengths[2]],mcoords)
+    np.testing.assert_allclose(types[2][:lengths[2]],mtypes)
+    np.testing.assert_allclose(radii[2][:lengths[2]],mradii.unsqueeze(1))
+    assert len(labels[2]) == len(mlabels)
+    assert labels[2][0] == mlabels[0]
+    assert labels[2][1] == mlabels[1]
         
 def test_duplicated_examples():
     '''This is for files with multiple ligands'''


### PR DESCRIPTION
Added a static method for a collate function to be used by `torch.utils.data.DataLoader`

Fixed the test for `MolDataset`, now passes.
Added testing for using `MolDataset` with `torch.utils.data.DataLoader` when using `molgrid.MolDataset.collateMolDataset`, passes tests