### PR TITLE
MolDataset -> MolMapDataset and MolIterDataset

### DIFF
--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -384,7 +384,7 @@ def test_pytorch_mapdataset():
 
     '''Testing out the collate_fn when used with torch.utils.data.DataLoader'''
     torch_loader = torch.utils.data.DataLoader(
-        m, batch_size=8, collate_fn=molgrid.MolDataset.collateMolDataset)
+        m, batch_size=8, collate_fn=molgrid.MolMapDataset.collateMolDataset)
     iterator = iter(torch_loader)
     next(iterator)
     lengths, center, coords, types, radii, labels = next(iterator)
@@ -462,7 +462,9 @@ def test_pytorch_iterdataset():
     assert radii.shape[0] == BSIZE
     assert labels.shape[0] == BSIZE
 
-    ex = e.next()
+    e.reset()
+    e.next_batch()
+    ex = e.next_batch()
     coordinates = ex[2].merge_coordinates()
     np.testing.assert_allclose(center[2], coordinates.coord_sets.center().tonumpy()) 
     np.testing.assert_allclose(coords[2,:lengths[2]], coordinates.coords.tonumpy())

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -465,7 +465,7 @@ def test_pytorch_iterdataset():
     e.next_batch()
     ex = e.next_batch()
     coordinates = ex[2].merge_coordinates()
-    np.testing.assert_allclose(center[2], ex[2].coord_sets[-1].center().tonumpy()) 
+    np.testing.assert_allclose(center[2], np.array(list(ex[2].coord_sets[-1].center()))) 
     np.testing.assert_allclose(coords[2,:lengths[2]], coordinates.coords.tonumpy())
     np.testing.assert_allclose(types[2,:lengths[2]], coordinates.type_index.tonumpy())
     np.testing.assert_allclose(radii[2,:lengths[2]], coordinates.radii.tonumpy())

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -433,7 +433,7 @@ def test_pytorch_iterdataset():
     m_iter = iter(m)
     
     ex = e.next()
-    coordinates = ex[0].merge_coordinates()
+    coordinates = ex.merge_coordinates()
 
     lengths, centers, coords, types, radii, labels = next(m_iter)
 

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -465,7 +465,7 @@ def test_pytorch_iterdataset():
     e.next_batch()
     ex = e.next_batch()
     coordinates = ex[2].merge_coordinates()
-    np.testing.assert_allclose(center[2], coordinates.coord_sets.center().tonumpy()) 
+    np.testing.assert_allclose(center[2], ex[2].coord_sets[-1].center().tonumpy()) 
     np.testing.assert_allclose(coords[2,:lengths[2]], coordinates.coords.tonumpy())
     np.testing.assert_allclose(types[2,:lengths[2]], coordinates.type_index.tonumpy())
     np.testing.assert_allclose(radii[2,:lengths[2]], coordinates.radii.tonumpy())

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -437,7 +437,7 @@ def test_pytorch_iterdataset():
 
     lengths, centers, coords, types, radii, labels = next(m_iter)
 
-    assert list(center.shape) == [3]
+    assert list(centers.shape) == [BSIZE,3]
     np.testing.assert_allclose(coords[0,:lengths[0],:], coordinates.coords.tonumpy())
     np.testing.assert_allclose(types[0,:lengths[0]], coordinates.type_index.tonumpy())
     np.testing.assert_allclose(radii[0,:lengths[0]], coordinates.radii.tonumpy())
@@ -458,7 +458,6 @@ def test_pytorch_iterdataset():
     assert center.shape[0] == BSIZE
     assert coords.shape[0] == BSIZE
     assert types.shape[0] == BSIZE
-    assert radii.shape[0] == BSIZE
     assert radii.shape[0] == BSIZE
     assert labels.shape[0] == BSIZE
 

--- a/test/test_example_provider.py
+++ b/test/test_example_provider.py
@@ -449,6 +449,7 @@ def test_pytorch_iterdataset():
     np.testing.assert_allclose(labels[0,-1], 0.162643)
 
     # ensure it works with more than 1 worker
+    m.examples.reset()
     torch_loader = torch.utils.data.DataLoader(
         m, batch_size=None, num_workers=2)
     iterator = iter(torch_loader)


### PR DESCRIPTION
Created a MolIterDataset which uses the ExampleProvider to provide a dataset with all the ExampleProviderSettings.

MolIterDataset is designed to be used with `torch.utils.data.Dataloader(batch_size=None)` since the ExampleProvider already provides a batch. Similarly to MolMapDataset, it returns a tuple of: lengths, centers, coords, atom_types, radii, and labels. These can be passed directly to `gridmaker.forward` to voxelize the batch. Translation and rotation of the examples is handled by the Dataset.